### PR TITLE
FEAT - Temporary File Streaming

### DIFF
--- a/bcaw/const.py
+++ b/bcaw/const.py
@@ -9,49 +9,53 @@
 # License, Version 3. See the text file "COPYING" for further details
 # about the terms of this license.
 #
-# Constants used across BitCurator modules.
-#
-# These need to map to the names used in the default config file, but better
-# than multiple hardcoded strings in code.
+"""Constants used across BitCurator modules.
+These need to map to the names used in the default config file, but better
+than multiple hardcoded strings in code.
+"""
 
 import datetime
 
-class ConfKey:
+class ConfKey(object):
+    """Config key string constatnts"""
     LOG_FORMAT = 'LOG_FORMAT'
-    LOG_FILE   = 'LOG_FILE'
-    IMAGE_DIR  = 'IMAGE_DIR'
+    LOG_FILE = 'LOG_FILE'
+    IMAGE_DIR = 'IMAGE_DIR'
 
-class Defaults:
+class Defaults(object):
+    """Default values"""
     NA = 'N/A'
     NULL_MD5 = 'd41d8cd98f00b204e9800998ecf8427e'
 
-class Extns:
+class Extns(object):
+    """File extensions for disk image types and XML."""
     E01 = '.e01'
     AFF = '.aff'
     RAW = '.raw'
-    DD  = '.dd'
+    DD = '.dd'
     ISO = '.iso'
     XML = '.xml'
     DFXML = '_dfxml' + XML
     # list of image types supporting system metadata
     META = [E01, E01.upper(), AFF, AFF.upper()]
     RAW = [RAW, RAW.upper(), DD, DD.upper(), ISO, ISO.upper()]
-    SUPPORTED = META + RAW;
+    SUPPORTED = META + RAW
     IGNORED = [XML, XML.upper()]
 
-# Extensions for text extraction support (via textract)
-# Make this smarter for release
-class FileExtns:
-    # See http://textract.readthedocs.io/en/stable/ for deps to support these
+
+class FileExtns(object):
+    """Extensions for text extraction support (via textract)
+    See http://textract.readthedocs.io/en/stable/ for deps to support these
+    """
     BASEEXT = ['csv', 'doc', 'docx', 'eml', 'epub', 'gif', 'jpg', \
                'jpeg', 'json', 'html', 'htm', 'mp3', 'msg', 'odt', \
                'ogg', 'pdf', 'png', 'pptx', 'ps', 'rtf', 'tiff', \
                'tif', 'txt', 'wav', 'xlsx', 'xls']
     # Lower and upper case list
-    ALLEXT = BASEEXT + map(lambda x:x.upper(),BASEEXT)
+    ALLEXT = BASEEXT + [x.upper() for x in BASEEXT]
 
-# Field names for mappings from EWF tags
-class ImgFlds:
+class ImgFlds(object):
+    """Field names for mappings from EWF tags"""
     PATH = 'path'
     NAME = 'name'
     ACQUIRED = 'acquired'
@@ -63,7 +67,7 @@ class ImgFlds:
     BPS = 'bps'
     SECTORS = 'sectors'
     SIZE = 'size'
-    MD5 ='md5'
+    MD5 = 'md5'
     DEFAULT = {
         ACQUIRED    : datetime.date.today(),
         SYS_DATE    : datetime.date.today(),
@@ -77,11 +81,12 @@ class ImgFlds:
         MD5         : Defaults.NULL_MD5
     }
 
-class PartFlds:
-    ADDR  = 'addr'
-    SLOT  = 'slot'
+class PartFlds(object):
+    """Database fields and defaults for DB partition table"""
+    ADDR = 'addr'
+    SLOT = 'slot'
     START = 'start'
-    DESC  = 'description'
+    DESC = 'description'
     IMAGE = 'image_id'
     DEFAULT = {
         ADDR  : 0,
@@ -90,13 +95,15 @@ class PartFlds:
         DESC  : Defaults.NA
     }
 
-class PathChars:
+class PathChars(object):
+    """File path separator characters"""
     PATH_SEP_FOR = '/'
     PATH_SEP_BACK = '\\'
     SEPS = [PATH_SEP_FOR, PATH_SEP_BACK]
 
-# EWF XMl element tags
-class EwfTags:
+
+class EwfTags(object):
+    """EWF XMl element tags"""
     # Parent tags
     EWINFO = 'ewfinfo'
     ACQ_INFO = 'acquiry_information'
@@ -119,7 +126,8 @@ class EwfTags:
     MEDIA_SIZE = 'media_size'
     HASH_DIGEST = 'hashdigest'
 
-class EwfTagMap:
+class EwfTagMap(object):
+    """Maps Expert Witness Format tags to DB Image table fields"""
     LOOKUP = {
         EwfTags.ACQ_DATE    : ImgFlds.ACQUIRED,
         EwfTags.SYS_DATE    : ImgFlds.SYS_DATE,
@@ -134,5 +142,6 @@ class EwfTagMap:
     }
 
 # Exceptions
-class ExcepMess:
+class ExcepMess(object):
+    """Messages for exceptions"""
     PARSING = 'Exception when parsing %s: %s'

--- a/bcaw/controller.py
+++ b/bcaw/controller.py
@@ -10,18 +10,19 @@
 # about the terms of this license.
 #
 
-import os, ntpath, urllib
-from flask import Flask, render_template, send_from_directory, Response, stream_with_context
+import logging
+import os
+import urllib
+from flask import Flask, render_template, send_file, send_from_directory
+from flask import Response, stream_with_context
 from bcaw import app
 from bcaw.const import ConfKey
 from bcaw.disk_utils import ImageDir, ImageFile, FileSysEle
-from bcaw.model import *
-
-# Keep a list of images
-IMAGE_DIR = ImageDir.fromRootDir(app.config[ConfKey.IMAGE_DIR])
+from bcaw.model import Image, Partition
 
 @app.route('/')
 def bcaw_home():
+    """BCAW application home page, test DB is synched and display home."""
     # If there's a different number of images on disk than
     # in the DB table it's time to synch
     if DbSynch.is_synch_db():
@@ -29,20 +30,23 @@ def bcaw_home():
 
     return render_template('home.html', db_images=Image.images())
 
-@app.route('/image/meta/<id>/')
-def image_meta(id):
-    image = Image.byId(id)
+@app.route('/image/meta/<image_id>/')
+def image_meta(image_id):
+    """Image metadata page, retrieves image info from DB and displays it."""
+    image = Image.byId(image_id)
     return render_template('image.html', image=image)
 
-@app.route('/image/data/<id>/')
-def image_dnld(id):
-    image = Image.byId(id)
+@app.route('/image/data/<image_id>/')
+def image_dnld(image_id):
+    """Image download request, returns the image binary"""
+    image = Image.byId(image_id)
     parent = os.path.abspath(os.path.join(image.path, os.pardir))
     return send_from_directory(parent, image.name, as_attachment=True)
 
-@app.route('/image/<id>/')
-def image_parts(id):
-    image = Image.byId(id)
+@app.route('/image/<image_id>/')
+def image_parts(image_id):
+    """Page listing the partition details for on image, retrieved from DB."""
+    image = Image.byId(image_id)
     logging.debug("Getting parts for image: " + image.name)
     for part in image.partitions.all():
         logging.debug("Part " + str(part.id))
@@ -50,70 +54,89 @@ def image_parts(id):
 
 @app.route('/image/<image_id>/<part_id>/')
 def part_root(image_id, part_id):
+    """Displays the root directory of a the chosen partition."""
     return file_handler(image_id, part_id, "/")
 
 @app.route('/image/<image_id>/<part_id>/', defaults={'encoded_filepath': '/'})
 @app.route('/image/<image_id>/<part_id>/<path:encoded_filepath>/')
 def file_handler(image_id, part_id, encoded_filepath):
+    """Display page for a file system element.
+    If the element is a directory then the page displays the directory listing
+    as read from the disk image.
+    If a file is selected they files contents as a binary payload is sent in
+    the Response.
+    """
     file_path = urllib.unquote(encoded_filepath)
     image = Image.byId(image_id)
-    imagePart = Partition.byId(part_id)
-    fsEle = FileSysEle.fromImagePath(image.path, imagePart, image.bps, file_path)
-    if fsEle.isDirectory():
+    image_part = Partition.byId(part_id)
+    fs_ele = FileSysEle.fromImagePath(image.path, image_part, image.bps, file_path)
+    if fs_ele.isDirectory():
         # Render the dir listing template
-        files = FileSysEle.listFiles(image.path, imagePart, image.bps, file_path)
-        return render_template('directory.html', image=image, partition=imagePart, files=files)
+        files = FileSysEle.listFiles(image.path, image_part, image.bps, file_path)
+        return render_template('directory.html', image=image,
+                               partition=image_part, files=files)
     # Its a file so return the download
-    generator, mime_type = FileSysEle.getPayload(image.path, imagePart.start, image.bps, fsEle)
-    return Response(stream_with_context(generator),
-                    mimetype=mime_type,
-                    headers={ "Content-Disposition" : "attachment;filename=" + fsEle.name })
+    temp_file, mime_type = FileSysEle.createTempCopy(image.path,
+                                                     image_part.start,
+                                                     image.bps, fs_ele)
+    return send_file(temp_file, mimetype=mime_type, as_attachment=True, attachment_filename=fs_ele.name)
 
 @app.route('/analysis/<image_id>/<part_id>/<path:encoded_filepath>')
 def analysis_handler(image_id, part_id, encoded_filepath):
+    """Page that displays analysis results for a file."""
     file_path = urllib.unquote(encoded_filepath)
     image = Image.byId(image_id)
-    imagePart = Partition.byId(part_id)
-    fsEle = FileSysEle.fromImagePath(image.path, imagePart, image.bps, file_path)
-    
+    image_part = Partition.byId(part_id)
+    fs_ele = FileSysEle.fromImagePath(image.path, image_part, image.bps, file_path)
+
     # Do something for directory handling here, not sure what yet
-    return render_template('analysis.html', image=image, partition=imagePart, file_path=file_path)
+    return render_template('analysis.html', image=image, partition=image_part, file_path=file_path)
 
 
-class DbSynch:
+class DbSynch(object):
+# Keep a list of images
+    """Class that synchs images in the application directory with the DB record.
+    """
+    image_dir = ImageDir.fromRootDir(app.config[ConfKey.IMAGE_DIR])
     __not_in_db__ = []
     __not_on_disk__ = []
 
     @classmethod
     def is_synch_db(cls):
+        """Returns true if the database needs resynching with file system."""
         cls.disk_synch()
-        return Image.imageCount() != IMAGE_DIR.imageCount()
+        return Image.imageCount() != DbSynch.image_dir.imageCount()
 
-    @staticmethod
-    def disk_synch():
-        IMAGE_DIR = ImageDir.fromRootDir(app.config[ConfKey.IMAGE_DIR])
+    @classmethod
+    def disk_synch(cls):
+        """Updates the list of disk images from the directory listing."""
+        cls.image_dir = ImageDir.fromRootDir(app.config[ConfKey.IMAGE_DIR])
 
     @classmethod
     def synch_db(cls):
+        """Updates the database with images found in the image directory."""
         if not cls.is_synch_db():
             return
         # Deal with images not in the database first
         cls.images_not_in_db()
         for image in cls.__not_in_db__:
             logging.info("Adding image: " + image.getPath() + " to database.")
-            modelImage = Image(**image.toImageDbMap())
-            Image.addImage(modelImage)
+            model_image = Image(**image.toImageDbMap())
+            Image.addImage(model_image)
             ImageFile.populateParts(image)
             for part in image.getPartitions():
-                Partition.addPart(Partition(**part.toPartDbMap(modelImage.id)))
+                Partition.addPart(Partition(**part.toPartDbMap(model_image.id)))
 
         for image in cls.__not_on_disk__:
-            logging.warn("Image: " + image.path + " appears to have been deleted from disk.");
+            logging.warn("Image: " + image.path + " appears to have been deleted from disk.")
 
     @classmethod
     def images_not_in_db(cls):
+        """Checks that images on the disk are also on database.
+        Missing images are added to a member list,
+        """
         del cls.__not_in_db__[:]
-        for image in IMAGE_DIR.images:
+        for image in cls.image_dir.images:
             db_image = Image.byPath(image.getPath())
             if db_image is None:
                 logging.debug("Image: " + image.getPath() + " not in database.")
@@ -121,8 +144,11 @@ class DbSynch:
 
     @classmethod
     def images_not_on_disk(cls):
+        """Checks that images in the database are also on disk.
+        Missing images are added to a member list,
+        """
         del cls.__not_on_disk__[:]
         for image in Image.images():
             if not os.path.isfile(image.path):
-                 logging.debug("Image: " + image.path + " is no longer on disk.")
-                 cls.__not_on_disk__.append(image)
+                logging.debug("Image: " + image.path + " is no longer on disk.")
+                cls.__not_on_disk__.append(image)

--- a/bcaw/disk_utils.py
+++ b/bcaw/disk_utils.py
@@ -11,13 +11,26 @@
 #
 # utils.py: various classless utilities, mostly disk based
 #
-import logging, os, ntpath, datetime, subprocess, time
+"""
+Disk based utilites for handling disk images.
+"""
+import logging
+import os
+import ntpath
+import datetime
+import subprocess
+import tempfile
+import time
 from mimetypes import MimeTypes
-from bcaw.const import *
-import pytsk3
 import xml.etree.ElementTree as ET
+import pytsk3
+from const import Extns, ImgFlds, ExcepMess, EwfTags, EwfTagMap
+from const import PartFlds, Defaults, FileExtns, PathChars
+
 
 class ImageDir(object):
+    """Class that encapsulates a root directory containing disk images.
+    """
     def __init__(self, root, images):
         self.root = root
         self.images = images
@@ -33,29 +46,92 @@ class ImageDir(object):
         root = root if root.endswith(os.path.sep) else root + os.path.sep
         images = []
         logging.info("Scanning " + root + " for disk images.")
-        for file in os.listdir(root):
-            if cls.is_image(file):
-                logging.info("Found image file: " + file)
-                images.append(ImageFile.fromFile(root + file))
+        for file_found in os.listdir(root):
+            if cls.is_image(file_found):
+                logging.info("Found image file: " + file_found)
+                images.append(ImageFile.fromFile(root + file_found))
         imageDir = cls(root, images)
         return imageDir
 
     @staticmethod
-    def is_image(file):
-        img_name, img_extension = os.path.splitext(file)
-        return img_extension in Extns.SUPPORTED
+    def is_image(to_check):
+        """
+        Checks if the supplied file name has a supported extension.
+        DOCTESTS:
+        >>> ImageDir.is_image('name.E01')
+        True
+        >>> ImageDir.is_image('name.e01')
+        True
+        >>> ImageDir.is_image('name.DD')
+        True
+        >>> ImageDir.is_image('name.ddd')
+        False
+        >>> ImageDir.is_image('name.pdf')
+        False
+        >>> ImageDir.is_image('name.pdf')
+        False
+        >>> ImageDir.is_image('name.xml')
+        False
+        """
+        return os.path.splitext(to_check)[1] in Extns.SUPPORTED
 
     @staticmethod
     def is_sysmeta(image):
-        imgname, img_extension = os.path.splitext(image)
-        return img_extension in Extns.META
+        """
+        Checks if the supplied file name has an extension suggesting that
+        system metadata can be extracted from it.
+        DOCTESTS:
+        >>> ImageDir.is_image('name.E01')
+        True
+        >>> ImageDir.is_image('name.e01')
+        True
+        >>> ImageDir.is_image('name.AFF')
+        True
+        >>> ImageDir.is_image('name.aff')
+        True
+        >>> ImageDir.is_image('name.DD')
+        True
+        >>> ImageDir.is_image('name.ddd')
+        False
+        >>> ImageDir.is_image('name.pdf')
+        False
+        >>> ImageDir.is_image('name.pdf')
+        False
+        >>> ImageDir.is_image('name.xml')
+        False
+        """
+        return os.path.splitext(image)[1] in Extns.META
 
     @staticmethod
     def is_raw(image):
-        imgname, img_extension = os.path.splitext(image)
-        return img_extension in Extns.RAW
+        """
+        Checks if the supplied file name has a raw image type extension.
+        DOCTESTS:
+        >>> ImageDir.is_image('name.raw')
+        True
+        >>> ImageDir.is_image('name.RAW')
+        True
+        >>> ImageDir.is_image('name.AFF')
+        True
+        >>> ImageDir.is_image('name.iso')
+        True
+        >>> ImageDir.is_image('name.ISO')
+        True
+        >>> ImageDir.is_image('name.DD')
+        True
+        >>> ImageDir.is_image('name.ddd')
+        False
+        >>> ImageDir.is_image('name.iSo')
+        False
+        >>> ImageDir.is_image('name.pdf')
+        False
+        >>> ImageDir.is_image('name.xml')
+        False
+        """
+        return os.path.splitext(image)[1] in Extns.RAW
 
 class ImageFile(object):
+
     def __init__(self, path, ewf_file=None, dfxml_file=None):
         self.path = path
         self.name = ntpath.basename(path)
@@ -98,12 +174,13 @@ class ImageFile(object):
         return ret_val
 
     @classmethod
-    def fromFile(cls, file):
-        if not os.path.isfile(file):
+    def fromFile(cls, source_file):
+        if not os.path.isfile(source_file):
             return
-        ewf_file = file + Extns.XML if os.path.isfile(file + Extns.XML) else ''
-        dfxml_file = file + Extns.DFXML if os.path.isfile(file + Extns.DFXML) else ''
-        imageFile = cls(file, ewf_file, dfxml_file)
+        ewf_file = source_file + Extns.XML if os.path.isfile(source_file + Extns.XML) else ''
+        dfxml_file = source_file + \
+            Extns.DFXML if os.path.isfile(source_file + Extns.DFXML) else ''
+        imageFile = cls(source_file, ewf_file, dfxml_file)
         return imageFile
 
     @staticmethod
@@ -120,10 +197,13 @@ class ImageFile(object):
             logging.error(ExcepMess.PARSING, xmlfile, e)
             return
 
-        root = tree.getroot() # root node
-        retVal = mapped_dict_from_element(root, EwfTags.PARENTS, EwfTagMap.LOOKUP)
-        retVal[ImgFlds.ACQUIRED] = date_string_to_date(retVal[ImgFlds.ACQUIRED])
-        retVal[ImgFlds.SYS_DATE] = date_string_to_date(retVal[ImgFlds.SYS_DATE])
+        root = tree.getroot()  # root node
+        retVal = mapped_dict_from_element(
+            root, EwfTags.PARENTS, EwfTagMap.LOOKUP)
+        retVal[ImgFlds.ACQUIRED] = date_string_to_date(
+            retVal[ImgFlds.ACQUIRED])
+        retVal[ImgFlds.SYS_DATE] = date_string_to_date(
+            retVal[ImgFlds.SYS_DATE])
         return retVal
 
     @staticmethod
@@ -131,10 +211,12 @@ class ImageFile(object):
         if imageFile.isEwf():
             ewfinfo_xml = imageFile.path + Extns.XML
             if not os.path.exists(ewfinfo_xml):
-                logging.info("Generating EWF for image: " + imageFile.getPath())
+                logging.info("Generating EWF for image: " +
+                             imageFile.getPath())
                 cmd = "ewfinfo -f dfxml " + imageFile.path + " > " + ewfinfo_xml
                 logging.debug('CMD: %s for xmlfile: %s', cmd, ewfinfo_xml)
-                proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+                proc = subprocess.Popen(
+                    cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
                 proc.wait()
             imageFile.ewf_file = ewfinfo_xml
 
@@ -150,15 +232,16 @@ class ImageFile(object):
             # defined. For file systems like FAT12, with no partition info, we need
             # to handle in an exception.
             try:
-                fs = pytsk3.FS_Info(image_info, offset=0)
+                fs_info = pytsk3.FS_Info(image_info, offset=0)
             except:
                 # Botch by populating with file system details
-                imageFile.__partitions__.append(ImagePart(-1, -1, -1, "Error Parsing"))
+                imageFile.__partitions__.append(
+                    ImagePart(-1, -1, -1, "Error Parsing"))
                 return
 
-            if fs.info.ftype == pytsk3.TSK_FS_TYPE_FAT12:
+            if fs_info.info.ftype == pytsk3.TSK_FS_TYPE_FAT12:
                 fs_desc = "FAT12 file system"
-            elif fs.info.ftype == pytsk3.TSK_FS_TYPE_ISO9660_DETECT:
+            elif fs_info.info.ftype == pytsk3.TSK_FS_TYPE_ISO9660_DETECT:
                 fs_desc = "ISO file system"
             else:
                 fs_desc = "Unknown file system"
@@ -182,16 +265,21 @@ class ImageFile(object):
                 # Open the file system for this image at the extracted
                 # start_offset.
                 try:
-                    fs = pytsk3.FS_Info(image_info, offset=(part.start * 512))
+                    fs_info = pytsk3.FS_Info(image_info, offset=(part.start * 512))
                 except:
                     # Exception, log and loop
-                    logging.warn("Sleuth toolkit exception thrown getting partition: " + str(part.slot_num) + " for image: " + imageFile.path)
+                    logging.warn("Sleuth toolkit exception thrown getting partition: " +
+                                 str(part.slot_num) + " for image: " + imageFile.path)
                     continue
 
-                logging.info("Adding partition: " + part.desc + " for image: " + imageFile.path)
-                imageFile.__partitions__.append(ImagePart(part.addr, part.slot_num, part.start, part.desc))
+                logging.info("Adding partition: " + part.desc +
+                             " for image: " + imageFile.path)
+                imageFile.__partitions__.append(
+                    ImagePart(part.addr, part.slot_num, part.start, part.desc))
+
 
 class ImagePart(object):
+
     def __init__(self, addr, slot, start, desc):
         self.addr = addr
         self.slot = slot
@@ -200,23 +288,29 @@ class ImagePart(object):
 
     def toPartDbMap(self, image_id):
         return {
-            PartFlds.ADDR  : self.addr,
-            PartFlds.SLOT  : self.slot,
-            PartFlds.START : self.start,
-            PartFlds.DESC  : self.desc,
-            PartFlds.IMAGE : image_id
+            PartFlds.ADDR: self.addr,
+            PartFlds.SLOT: self.slot,
+            PartFlds.START: self.start,
+            PartFlds.DESC: self.desc,
+            PartFlds.IMAGE: image_id
         }
 
+
 class FileSysEle(object):
-    #def __init__(self, path, size, mode, mtime, atime, ctime, addr, isDir, isDeleted):
+    # def __init__(self, path, size, mode, mtime, atime, ctime, addr, isDir,
+    # isDeleted):
+
     def __init__(self, path, size, mode, mtime, atime, ctime, addr, isDir, isDeleted, isCandidate):
         self.path = path
         self.name = ntpath.basename(path)
         self.size = size
         self.mode = mode
-        self.mtime = datetime.datetime.fromtimestamp(mtime).isoformat() if mtime != 0 else Defaults.NA
-        self.atime = datetime.datetime.fromtimestamp(atime).isoformat() if atime != 0 else Defaults.NA
-        self.ctime = datetime.datetime.fromtimestamp(ctime).isoformat() if ctime != 0 else Defaults.NA
+        self.mtime = datetime.datetime.fromtimestamp(
+            mtime).isoformat() if mtime != 0 else Defaults.NA
+        self.atime = datetime.datetime.fromtimestamp(
+            atime).isoformat() if atime != 0 else Defaults.NA
+        self.ctime = datetime.datetime.fromtimestamp(
+            ctime).isoformat() if ctime != 0 else Defaults.NA
         self.addr = addr
         self.isDir = isDir
         self.isDeleted = isDeleted
@@ -233,29 +327,37 @@ class FileSysEle(object):
     @classmethod
     def fromImagePath(cls, image_path, imagePart, block_size, path):
         parent_path, file_name = os.path.split(path)
-        if (is_root(parent_path, file_name)):
+        if is_root(parent_path, file_name):
             rootEle = cls.rootElement()
             return rootEle
-        return cls.getFileFromDir(image_path, imagePart.start, block_size, parent_path, file_name)
+        return cls.getFileFromDir(image_path, imagePart.start, block_size,
+                                  parent_path, file_name)
 
     @classmethod
-    def getFileFromDir(cls, image_path, start, block_size, parent_path, file_name):
+    def getFileFromDir(cls, image_path, start, block_size, parent_path,
+                       file_name):
         file_sys_info = cls.getFileSystemInfo(image_path, start, block_size)
         parent_dir = file_sys_info.open_dir(path=parent_path)
-        for file in parent_dir:
-            if (file.info.meta != None) and (file.info.name.name == file_name):
-                logging.debug("Found file: " + file.info.name.name + " against " + file_name)
-                return cls.fromFileInfo(parent_path, file.info)
+        for child_file in parent_dir:
+            if (child_file.info.meta != None) and (child_file.info.name.name == file_name):
+                logging.debug("Found file: " +
+                              child_file.info.name.name + " against " + file_name)
+                return cls.fromFileInfo(parent_path, child_file.info)
         return None
 
     @classmethod
     def fromFileInfo(cls, path, info):
-        ele = cls(path + info.name.name, info.meta.size, info.meta.mode, info.meta.mtime, info.meta.atime, info.meta.ctime, info.meta.addr, is_dir(info.meta.type), is_deleted(info), is_candidate(info))
+        """Creates a new FileSysEle instance from the supplied params"""
+        ele = cls(path + info.name.name, info.meta.size, info.meta.mode,
+                  info.meta.mtime, info.meta.atime, info.meta.ctime,
+                  info.meta.addr, is_dir(info.meta.type), is_deleted(info),
+                  is_candidate(info))
         return ele
 
     @staticmethod
     def getFileSystemInfo(image_path, start, block_size):
-        logging.debug("Getting Image info for:" + image_path + " start:" + str(start) + " size:" + str(block_size))
+        logging.debug("Getting Image info for:" + image_path +
+                      " start:" + str(start) + " size:" + str(block_size))
         image_info = pytsk3.Img_Info(image_path)
         # Open the file system for this image at the extracted
         # start_offset.
@@ -266,54 +368,81 @@ class FileSysEle(object):
     @classmethod
     def listFiles(cls, image_path, imagePart, block_size, path):
         file_list = []
-        file_sys_info = cls.getFileSystemInfo(image_path, imagePart.start, block_size)
+        file_sys_info = cls.getFileSystemInfo(
+            image_path, imagePart.start, block_size)
         directory = file_sys_info.open_dir(path=path)
-        for file in directory:
-            if file.info.meta != None:
-                file_list.append(FileSysEle.fromFileInfo('/' + path + '/', file.info))
+        for listed_file in directory:
+            if listed_file.info.meta != None:
+                file_list.append(FileSysEle.fromFileInfo(
+                    '/' + path + '/', listed_file.info))
         return file_list
 
     @classmethod
-    def getPayload(cls, image_path, start, block_size, fsEle):
+    def createTempCopy(cls, image_path, start, block_size, fsEle):
+        """Creates a temp file copy of a file from the specified image."""
+        mime_type = cls.GuessMimeType(fsEle.name)
+        generator = cls.payloadGenerator(image_path, start, block_size, fsEle)
+
+        # Open with a named temp file
+        with tempfile.NamedTemporaryFile(delete=False) as temp:
+            for data in generator:
+                temp.write(data)
+                temp.flush()
+            # Return an opened temp file
+            return temp.name, mime_type
+
+    @classmethod
+    def payloadGenerator(cls, image_path, start, block_size, fsEle):
+        """Generator used to loop through a file's content."""
+        logging.debug("Getting image file information")
         file_sys_info = cls.getFileSystemInfo(image_path, start, block_size)
-        file = file_sys_info.open_meta(inode=fsEle.addr)
-
-        # Read data and store it in a string
+        image_file = file_sys_info.open_meta(inode=fsEle.addr)
+        # Set up the date copy process vars
         offset = 0
-        size = file.info.meta.size
-        BUFF_SIZE = 1024 * 1024
-
-        total_data = ""
-        while offset < size:
-            available = min(BUFF_SIZE, size - offset)
-            data = file.read_random(offset, available)
+        file_size = image_file.info.meta.size
+        buff_size = 1024 * 1024
+        # Loop through data read and yield it 1MB chunk at a time
+        logging.debug("Starting delivery loop, file_size:" + str(file_size) + " Bytes.")
+        while offset < file_size:
+            available = min(buff_size, file_size - offset)
+            data = image_file.read_random(offset, available)
+            offset += len(data)
+            # If no data then break the generator loop
             if not data:
                 break
-            offset += len(data)
-            total_data = total_data+data
+            yield data
 
-        mime = MimeTypes()
-        mime_type, a = mime.guess_type(fsEle.name)
-        generator = (cell for row in total_data
-                        for cell in row)
-        return generator, mime_type
+    @classmethod
+    def GuessMimeType(cls, file_name):
+        """Function to guess the MIME type of a file by filename extension.
+        DOCTESTS:
+        >>> FileSysEle.GuessMimeType('name.pdf')
+        'application/pdf'
+        >>> FileSysEle.GuessMimeType('name.docx')
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+        >>> FileSysEle.GuessMimeType('name.xls')
+        'application/vnd.ms-excel'
+        >>> FileSysEle.GuessMimeType('name.txt')
+        'text/plain'
+        """
+        return MimeTypes().guess_type(file_name)[0]
 
-#
-# Recursively parses an XML structure and maps tag names / tag values to the
-# equivalent database field names. This info is stacked up in a dictionary that
-# the fucntion returns.
-# parent_tags: a list of tag values that are parents and should be recursed into
-# tag_dict: a dictionary of tag-values that map to the database field name
-#
 def mapped_dict_from_element(root, parent_tags, tag_dict):
+    """
+    Recursively parses an XML structure and maps tag names / tag values to the
+    equivalent database field names. This info is stacked up in a dictionary that
+    the function returns.
+    parent_tags: a list of tag values that are parents and should be recursed into
+    tag_dict: a dictionary of tag-values that map to the database field name
+    """
     mapped_dict = dict()
     for child in root:
         # Parent element so recurse and merge the returned map
-        if (child.tag in parent_tags):
+        if child.tag in parent_tags:
             child_dict = mapped_dict_from_element(child, parent_tags, tag_dict)
             mapped_dict.update(child_dict)
         # Mapped element, add the value to the returned dict
-        elif (child.tag in tag_dict):
+        elif child.tag in tag_dict:
             field = tag_dict[child.tag]
             mapped_dict[field] = child.text
     return mapped_dict
@@ -322,23 +451,28 @@ def date_string_to_date(date_string):
     return datetime.datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%S")
 
 def strip_mtime(mtime):
-    return time.strftime("%FT%TZ",time.gmtime(mtime))
+    return time.strftime("%FT%TZ", time.gmtime(mtime))
 
 def is_deleted(info):
-    return (int(info.meta.flags) & 0x01 == 0)
+    return int(info.meta.flags) & 0x01 == 0
 
-# Check if this is a candidate for text extraction
+
 def is_candidate(info):
-    # Get just the extension (this is dirty, also gets dotfile names now)
-    fa = (info.name.name).rsplit('.',1)
-    if len(fa) > 1:
-        return fa[1] in FileExtns.ALLEXT
+    """Check if this is a candidate for text extraction
+    Get just the extension (this is dirty, also gets dotfile names now)
+    """
+    file_ext = (info.name.name).rsplit('.', 1)
+    if len(file_ext) > 1:
+        return file_ext[1] in FileExtns.ALLEXT
         #logging.debug("End after split:" + fa[1])
-    else: 
+    else:
         return False
 
-def is_dir(meta_type):
-    return (meta_type == 2)
 
-def is_root(parent, file):
-    return (parent in PathChars.SEPS) and not file
+def is_dir(meta_type):
+    """Checks the meta_type from image info to see if the element is a directory
+    """
+    return meta_type == 2
+
+def is_root(parent, file_to_check):
+    return (parent in PathChars.SEPS) and not file_to_check

--- a/provision/bootstrap.sh
+++ b/provision/bootstrap.sh
@@ -21,6 +21,8 @@
 # vim: softtabstop=4 shiftwidth=4 expandtab fenc=utf-8 spell spelllang=en cc=81
 #===============================================================================
 #
+# Script Version
+__ScriptVersion="0.7"
 # Base directory for build log
 LOG_BASE=/var/log
 WWW_ROOT=/var/www
@@ -534,7 +536,7 @@ install_source_packages() {
         sed -i "s/ANT=JAVA_HOME=\/usr\/lib\/jvm\/java-7-oracle/ANT=JAVA_HOME=\/usr\/lib\/jvm\/java-7-openjdk-amd64/g" temp
         sed -i -e '/Debian Jessie 64-bit/r temp' Makefile
         make >> $LOG_BASE/bca-install.log 2>&1
-        sudo make install >> $LOG_BASE/bca-install.log 2>&1
+        sudo make install |& sudo tee -a $LOG_BASE/bca-install.log
         sudo ldconfig
         # Clean up
         # rm -rf /tmp/pylucene-6.2.0*
@@ -637,7 +639,7 @@ install_source_packages() {
         cd libqcow-20160123
         ./configure --enable-python >> $LOG_BASE/bca-install.log 2>&1
         make >> $LOG_BASE/bca-install.log 2>&1
-        sudo make install >> $LOG_BASE/bca-install.log 2>&1
+        sudo make install |& sudo tee -a  $LOG_BASE/bca-install.log
         sudo ldconfig
 
   # Install The Sleuth Kit
@@ -649,7 +651,7 @@ install_source_packages() {
         ./bootstrap >> $LOG_BASE/bca-install.log 2>&1
         ./configure >> $LOG_BASE/bca-install.log 2>&1
         make >> $LOG_BASE/bca-install.log 2>&1
-        sudo make install >> $LOG_BASE/bca-install.log 2>&1
+        sudo make install |& sudo tee -a $LOG_BASE/bca-install.log
         sudo ldconfig
         # Clean up
         rm /tmp/sleuthkit-4.2.0.tar.gz


### PR DESCRIPTION
- cleaned minor bash lint warnings in provision/bootstrap.sh;
- started to add Python DocStrings;
- added example Python DocTests to disk_utils;
- tidied some pylint warnings:
  * naming conventions;
  * import structure warnings;
  * missing documentation (hence DocString); and
  * some construct warnings;
- removed old getPayload() method from disk_utils.py;
- added payloadGenerator() to deliver files in 1MB chunks; and
- added createTempCopy() function that uses generator to create
a named temporary file, now used by controller.py.

To run the DocTests from within an activated VM venv,
e.g. ```cd /var/www/bcaw/venv && ./bin/activate``` issue the
command ```python -m doctest -v ../bcaw/disk_utils.py```.