### PR TITLE
FEAT - Compound partition IDs

### DIFF
--- a/bcaw/config.py
+++ b/bcaw/config.py
@@ -68,6 +68,7 @@ class AnalyserConfig(BaseConfig):# pylint: disable-msg=R0903
     NAME = "Analyser"
     LOG_FORMAT = '[%(asctime)-15s %(levelname)-8s %(filename)-15s:'+\
                  '%(lineno)-5d %(funcName)-30s] %(message)s'
+    LOG_FILE = LOG_ROOT + 'bcaw-analyser.log'
 
 CONFIGS = {
     "default": 'bcaw.config.BaseConfig',

--- a/bcaw/templates/directory.html
+++ b/bcaw/templates/directory.html
@@ -23,7 +23,7 @@
         {% for file in files %}
         <tr>
           <td><span class="glyphicon glyphicon-{{ 'folder-open' if file.is_directory else 'file' }}" aria-hidden="true"></span></td>
-          <td><a href="{{ "/image/" + image.id|string + "/" + partition.id|string + file.path }}" >{{ file.name }}</a></td>
+          <td><a href="{{ "/image/" + image.id|string + "/table/" + partition.table|string + "/slot/" + partition.slot|string + file.path }}" >{{ file.name }}</a></td>
           <td>{{ file.size|sizeof_fmt }}</td>
           <td>{{ file.details.ctime }}</td>
           <td>{{ file.details.mtime }}</td>
@@ -32,7 +32,7 @@
           {% elif file.is_directory %}
           <td></td>
           {% else %}
-          <td><a href="{{ "/raw/" + image.id|string + "/" + partition.id|string + file.path }}" ><span class="glyphicon glyphicon-save" aria-hidden="true"></span></a></td>
+          <td><a href="{{ "/raw/" + image.id|string + "/table/" + partition.table|string + "/slot/" + partition.slot|string + file.path }}" ><span class="glyphicon glyphicon-save" aria-hidden="true"></span></a></td>
           {% endif %}
         </tr>
         {% endfor %}

--- a/bcaw/templates/partitions.html
+++ b/bcaw/templates/partitions.html
@@ -60,7 +60,8 @@
         <table id="partitions" class="table table-striped">
           <thead>
             <tr>
-              <th>Id</th>
+              <th>Table</th>
+              <th>Slot</th>
               <th>Name</th>
               <th>File System</th>
               <th>Start</th>
@@ -69,8 +70,9 @@
           <tbody>
             {% for part in partitions %}
             <tr>
-              <td>{{ part.id }}</td>
-              <td><a href="{{ "/image/" + image.id|string + "/" + part.id|string }}" >{{ image.name }}</a></td>
+              <td>{{ part.table }}</td>
+              <td>{{ part.slot }}</td>
+              <td><a href="{{ "/image/" + image.id|string + "/table/" + part.table|string + "/slot/" + part.slot|string }}" >{{ image.name }}</a></td>
               <td>{{ part.description }}</td>
               <td>{{ part.start }}</td>
             </tr>

--- a/bcaw/templates/search_results.html
+++ b/bcaw/templates/search_results.html
@@ -22,7 +22,7 @@
         {% for byte_sequence in byte_sequences %}
         {% for file_ele in byte_sequence.file_elements %}
         <tr>
-          <td><a href="{{ "/image/" + file_ele.partition.image.id|string + "/" + file_ele.partition.id|string +"/" + file_ele.path }}" >{{ file_ele.name }}</a></td>
+          <td><a href="{{ "/image/" + file_ele.partition.image.id|string + "/table/" + part.table|string + "/slot/" + file_ele.part.slot|string +"/" + file_ele.path }}" >{{ file_ele.name }}</a></td>
           <td>{{ byte_sequence.sha1 }}</td>
           <td>{{ byte_sequence.mime_type }}</td>
           <td>{{ byte_sequence.size|sizeof_fmt }}</td>

--- a/bcaw/templates/table_sort.html
+++ b/bcaw/templates/table_sort.html
@@ -5,7 +5,11 @@
       $(document).ready(function() {
          $('#{{ table_id }}').DataTable({
            pageLength: 50,
-           stateSave: true
+           stateSave: true,
+           "language": {
+             "search": "Find",
+             "searchPlaceholder": "in table..."
+           }
          });
        } );
     </script>

--- a/scripts/restart-dev.sh
+++ b/scripts/restart-dev.sh
@@ -13,7 +13,8 @@ BCAW_ROOT="$WWW_ROOT/bcaw"
 BCAW_TARGET="$BCAW_ROOT/bcaw"
 SOURCE_ROOT="/vagrant"
 BCAW_SOURCE="$SOURCE_ROOT/bcaw"
-
+CONF_SOURCE="$SOURCE_ROOT/conf"
+CONF_TARGET="$BCAW_ROOT/conf"
 if [ -d "$BCAW_TARGET" ]; then
   find "$BCAW_TARGET" -name "*.pyc" -type f -exec rm {} \;
 fi
@@ -29,6 +30,8 @@ fi
 
 cp -f "$SOURCE_ROOT/"*.py "$BCAW_ROOT"
 cp -fr "$BCAW_SOURCE" "$BCAW_ROOT"
+cp -fr "$CONF_SOURCE" "$CONF_TARGET"
+
 chown www-data:www-data "$BCAW_ROOT/"*.py
 chown -R www-data:www-data "$BCAW_TARGET"
 sudo rm /var/log/bcaw.log


### PR DESCRIPTION
- added partition table property for `Partition` model class;
- `Partition` primary key now a compound of `image_id`, `table`, and `slot`;
- `disk_utils.py` now parses partition table;
- changes in `controller.py` routes:
  * added route variables for partition table and slot;
  * removed unused image metadata route; and
  * re-ordered some route verbs;
- updated template URLs to match new routes plus added new partition details to display;
- ensured dict constants are copied before use;
- fixed text for table searches;
- development restart script now copies updated configs;
- tidied logging string formatting plus extra logging detail; and
- given analyser separate log file in `config.py`.