### PR TITLE
Feat/mounted images

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,6 +22,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # In the example below, the first folder would be located on the host
     # at "/mnt/data", and the shared folder in the VM woud appear at "/vagrant/data"
     # config.vm.synced_folder "/mnt/data", "/vagrant/data"
+    config.vm.synced_folder "./disk-images", "/var/bcaw/disk-images", owner: "www-data", group: "www-data", mount_options: ["ro","dmode=0755", "fmode=0444"]
 
     # Port forward HTTP (80) to host 2020
     config.vm.network :forwarded_port, :host => 8080, :guest => 80

--- a/bcaw/config.py
+++ b/bcaw/config.py
@@ -42,7 +42,7 @@ class BaseConfig(object):# pylint: disable-msg=R0903
     GROUPS = [
         {
             'name' : 'Test Images',
-            'path' : '/var/www/bcaw/disk-images',
+            'path' : '/var/bcaw/disk-images',
             'description' : 'The set of test disk images supplied with BitCurator.'
         }
     ]

--- a/conf/groups.conf
+++ b/conf/groups.conf
@@ -1,17 +1,17 @@
 GROUPS = [
     {
         'name' : 'Mixed test',
-        'path' : '/var/www/bcaw/disk-images/mixed',
+        'path' : '/var/bcaw/disk-images/mixed',
         'description' : 'Set of mixed-format test disk images.'
     },
     {
         'name' : 'ISO test',
-        'path' : '/var/www/bcaw/disk-images/iso',
+        'path' : '/var/bcaw/disk-images/iso',
         'description' : 'Set of ISO test disk images.'
     },
     {
         'name' : 'All Images',
-        'path' : '/var/www/bcaw/disk-images',
+        'path' : '/var/bcaw/disk-images',
         'description' : 'All images included recursively.'
     }
 ]

--- a/provision/bootstrap.sh
+++ b/provision/bootstrap.sh
@@ -758,7 +758,7 @@ get_spacy_language_models
 # install_dfvfs
 
 # Copy over disk images
-copy_disk_images
+# copy_disk_images
 
 copy_source
 

--- a/provision/bootstrap.sh
+++ b/provision/bootstrap.sh
@@ -355,6 +355,9 @@ install_ubuntu_pip_packages() {
         fi
     done
 
+    # Clean pip cachee
+    rm -rf ~/.cache/pip
+
     # Prep environment for special packages, install cld2-cffi
     env CC=/usr/bin/gcc-5 pip3 install -U cld2-cffi
 
@@ -543,12 +546,12 @@ create_virtualenv() {
   if [ -d "$WWW_ROOT" ]; then
   	rm -rf "$WWW_ROOT"
   fi
-   mkdir "$WWW_ROOT"
-   mkdir "$BCAW_ROOT"
-   chmod -R 777 "$BCAW_ROOT"
-   chown -R www-data:www-data "$BCAW_ROOT"
-   virtualenv "$BCAW_ROOT/venv"
-   source "$BCAW_ROOT/venv/bin/activate"
+  mkdir -p "$WWW_ROOT"
+  mkdir -p "$BCAW_ROOT"
+  chmod -R 777 "$BCAW_ROOT"
+  chown -R www-data:www-data "$BCAW_ROOT"
+  virtualenv "$BCAW_ROOT/venv"
+  source "$BCAW_ROOT/venv/bin/activate"
 }
 
 copy_source() {
@@ -607,7 +610,7 @@ configure_webstack() {
     rm -rf "$WWW_ROOT/run"
   fi
 
-   mkdir "$WWW_ROOT/run"
+   mkdir -p "$WWW_ROOT/run"
    chown www-data:www-data "$WWW_ROOT/run"
    chmod 777 "$WWW_ROOT/run"
 
@@ -630,7 +633,7 @@ configure_webstack() {
 
    # Start and enable bcaw
    systemctl start bcaw
-   systemctl enable bcaw
+   systemctl enable bcaw 2>&1 
 
    # Start UWSGI and NGINX
    #if [ $VER == "17.04" ]; then
@@ -644,14 +647,16 @@ configure_webstack() {
    usermod -a -G www-data vagrant
 
    # Set up the cache + index directory
-   mkdir "$CACHE_DIR"
+   mkdir -p "$CACHE_DIR"
    chown www-data:www-data "$CACHE_DIR"
-   mkdir "$LUCENE_INDEX"
+
+   mkdir -p "$LUCENE_INDEX"
+
    chmod 775 "$LUCENE_INDEX"
    chown www-data:www-data "$LUCENE_INDEX"
 
    # Add the image indexing script to the chrontab
-   sudo -u vagrant crontab -l > /tmp/cron
+   sudo -u vagrant crontab -l 2>/dev/null > /tmp/cron || true # Suppress error message on normal condition where no crontab exists
    sudo -u vagrant echo "0 17 * * sun /vagrant/scripts/index_collections.sh" >> /tmp/cron
    sudo -u vagrant crontab /tmp/cron
    rm /tmp/cron

--- a/provision/bootstrap.sh
+++ b/provision/bootstrap.sh
@@ -355,7 +355,7 @@ install_ubuntu_pip_packages() {
         fi
     done
 
-    # Clean pip cachee
+    # Clean pip cache
     rm -rf ~/.cache/pip
 
     # Prep environment for special packages, install cld2-cffi

--- a/tests/group_config/groups.conf
+++ b/tests/group_config/groups.conf
@@ -1,17 +1,17 @@
 GROUPS = [
     {
         'name' : 'Mixed test',
-        'path' : '../disk-images/mixed',
+        'path' : '../../../bcaw/disk-images/mixed',
         'description' : 'Set of mixed-format test disk images.'
     },
     {
         'name' : 'ISO test',
-        'path' : '../disk-images/iso',
+        'path' : '../../../bcaw/disk-images/iso',
         'description' : 'Set of ISO test disk images.'
     },
     {
         'name' : 'All Images',
-        'path' : '../disk-images',
+        'path' : '../../../bcaw/disk-images',
         'description' : 'All images included recursively.'
     }
 ]


### PR DESCRIPTION
Allows all images to be bind-mounted into the VM using a read-only mount to avoid copying large images in and prevent changes to images.
